### PR TITLE
chore: add year pattern regex to .licenserc.yaml

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -16,7 +16,20 @@ header:
   license:
     spdx-id: "Apache-2.0"
     copyright-owner: "Google LLC"
-    copyright-year: "2025"
+    pattern: |
+      Copyright 202[56] Google LLC
+
+      Licensed under the Apache License, Version 2.0 \(the "License"\);
+      you may not use this file except in compliance with the License\.
+      You may obtain a copy of the License at
+
+           http://www\.apache\.org/licenses/LICENSE-2\.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied\.
+      See the License for the specific language governing permissions and
+      limitations under the License\.
   paths:
     - "**/*.yaml"
     - "**/*.yml"


### PR DESCRIPTION
Replicating license pattern change to allow 2025 and 2026.