### PR TITLE
feat(plugin): support agent plugin spec

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,1 +1,2 @@
 https://github.com/gemini-cli-extensions/spanner/compare/
+https://agent-plugins.org/compatible-clients

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This repository provides a set of agent skills to interact with [Google Cloud Sp
     - [Claude Code](#claude-code)
     - [Codex](#codex)
     - [Antigravity](#antigravity)
+- [Installing via a compatible Agent Plugins client](#installing-via-a-compatible-agent-plugins-client)
 - [Usage Examples](#usage-examples)
 - [Supported Skills](#supported-skills)
 - [Additional Agent Skills](#additional-agent-skills)
@@ -211,6 +212,19 @@ Set your environment vars as described in the [configuration section](#configura
 _(Tip: Antigravity automatically discovers skills in these directories at the start of a session.)_
 
 </details>
+
+## Installing via a compatible Agent Plugins client
+
+This repository is a valid [Agent Plugins](https://github.com/agentplugins/agent-plugins-spec) (v1) plugin. Any [Agent Plugins–compatible client](https://agent-plugins.org/compatible-clients) can install it directly using its own built-in plugin command — no extra tooling required — by pointing at this repository:
+
+```
+https://github.com/gemini-cli-extensions/spanner
+```
+
+Beyond harnesses covered by the native install above, compatible clients include VS Code, Cursor, GitHub Copilot, and Kiro. See your agent's documentation for its exact install command.
+
+**Set env vars:**
+Set your environment vars as described in the [configuration section](#configuration).
 
 <!-- {x-release-please-end} -->
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "spanner",
   "version": "0.3.1",
   "description": "Connect and interact with Spanner data using natural language.",
@@ -7,7 +8,10 @@
     "email": "data-cloud-ai-integrations@google.com"
   },
   "homepage": "https://cloud.google.com/spanner",
-  "license": "Apache-2.0",
   "repository": "https://github.com/gemini-cli-extensions/spanner",
-  "skills": "./skills/"
+  "license": "Apache-2.0",
+  "keywords": [
+    "spanner",
+    "database"
+  ]
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -43,6 +43,11 @@
           "type": "json",
           "path": ".claude-plugin/plugin.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "plugin.json",
+          "jsonpath": "$.version"
         }
       ]
     }


### PR DESCRIPTION
Add a spec-compliant root plugin.json so this repo installs into any Agent Plugins (v1) compatible client, plus a README install section. Track plugin.json version via release-please and remove userConfig from .claude-plugin/plugin.json (no longer visible to scripts).